### PR TITLE
Dlw266/register sidebar

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,12 @@
 .App {
   text-align: center;
-  padding: 0% 2%;
+  padding: 0 0;
+  margin: 0 0;
+}
+
+body {
+  padding: 0 0;
+  margin: 0 0;
 }
 
 .App-logo {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,12 +8,33 @@ import SocialTag from './components/Tags/SocialTags/SocialTag';
 import CategoryTag from './components/Tags/CategoryTags/CategoryTag';
 import { TokenProvider } from './context/TokenContext';
 import './App.css';
+import ClubProfile from './components/ClubRegistration/ClubEditSubpages/ClubProfile';
+import ClubRecruitment from './components/ClubRegistration/ClubEditSubpages/ClubRecruitment';
+import ClubDescription from './components/ClubRegistration/ClubEditSubpages/ClubDescription';
+import ClubEvents from './components/ClubRegistration/ClubEditSubpages/ClubEvents';
+import { sidebarPaths } from './components/ClubRegistration/Sidebar';
 
 function App() {
   return (
     <div className="App">
       <Router>
         <Routes>
+          <Route
+            path={'/register/' + sidebarPaths[0]}
+            element={<ClubProfile />}
+          />
+          <Route
+            path={'/register/' + sidebarPaths[1]}
+            element={<ClubRecruitment />}
+          />
+          <Route
+            path={'/register/' + sidebarPaths[2]}
+            element={<ClubDescription />}
+          />
+          <Route
+            path={'/register/' + sidebarPaths[3]}
+            element={<ClubEvents />}
+          />
           <Route path="/register" element={<ClubRegistration />} />
           <Route path="/clubs/:id" element={<InfoPage />} />
           <Route path="/" element={<ClubBoard />} />

--- a/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubDescription.tsx
+++ b/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubDescription.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import NavBar from '../../../components/NavBar/NavBar';
+import Sidebar from '../Sidebar';
+import '../ClubRegistration.css';
+
+const ClubDescription = () => {
+  return (
+    <>
+      <NavBar hasSearch={false} />
+      <div className="page-container">
+        <Sidebar currentPath={2} />
+        <div className="container">Club Description Page</div>
+      </div>
+    </>
+  );
+};
+
+export default ClubDescription;

--- a/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubEvents.tsx
+++ b/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubEvents.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import NavBar from '../../../components/NavBar/NavBar';
+import Sidebar from '../Sidebar';
+import '../ClubRegistration.css';
+
+const ClubEvents = () => {
+  return (
+    <>
+      <NavBar hasSearch={false} />
+      <div className="page-container">
+        <Sidebar currentPath={3} />
+        <div className="container">Club Events Page</div>
+      </div>
+    </>
+  );
+};
+
+export default ClubEvents;

--- a/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubProfile.tsx
+++ b/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubProfile.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import NavBar from '../../../components/NavBar/NavBar';
+import Sidebar from '../Sidebar';
+import '../ClubRegistration.css';
+
+const ClubProfile = () => {
+  return (
+    <>
+      <NavBar hasSearch={false} />
+      <div className="page-container">
+        <Sidebar currentPath={0} />
+        <div className="container">Club Profile Page</div>
+      </div>
+    </>
+  );
+};
+
+export default ClubProfile;

--- a/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubRecruitment.tsx
+++ b/frontend/src/components/ClubRegistration/ClubEditSubpages/ClubRecruitment.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import NavBar from '../../../components/NavBar/NavBar';
+import Sidebar from '../Sidebar';
+import '../ClubRegistration.css';
+
+const ClubRecruitment = () => {
+  return (
+    <>
+      <NavBar hasSearch={false} />
+      <div className="page-container">
+        <Sidebar currentPath={1} />
+        <div className="container">Club Recruitment Page</div>
+      </div>
+    </>
+  );
+};
+
+export default ClubRecruitment;

--- a/frontend/src/components/ClubRegistration/ClubRegistration.css
+++ b/frontend/src/components/ClubRegistration/ClubRegistration.css
@@ -4,3 +4,66 @@
   flex-direction: column;
   gap: 1em;
 }
+
+.page-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+}
+
+.sidebar {
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  align-self: flex-start;
+}
+
+.sidebar-item {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+
+  height: 50px;
+
+  font-family: 'Nunito';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 27px;
+
+  color: #35c1fd;
+
+  text-align: left;
+  padding-left: 75px;
+}
+
+.sidebar-item-highlighted {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+
+  font-family: 'Nunito';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 27px;
+
+  height: 50px;
+
+  color: #35c1fd;
+  border-radius: 0 20px 20px 0;
+  background: #35c1fd1a;
+
+  text-align: left;
+  padding-left: 75px;
+}

--- a/frontend/src/components/ClubRegistration/ClubRegistration.tsx
+++ b/frontend/src/components/ClubRegistration/ClubRegistration.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './ClubRegistration.css';
 import Dropdown from './Dropdown/Dropdown';
 import NavBar from '../../components/NavBar/NavBar';
+import Sidebar from './Sidebar';
 
 const ClubRegistration = () => {
   // Controlled values for all the form elements
@@ -18,13 +19,14 @@ const ClubRegistration = () => {
     event.preventDefault();
     alert('Submit Action Triggered!');
 
-    //NOT IMPLEMENTED: SUBMIT DATA STORED IN REACT HOOKS TO BACKEND
+    //TODO NOT IMPLEMENTED: SUBMIT DATA STORED IN REACT HOOKS TO BACKEND
   }
 
   return (
     <>
       <NavBar hasSearch={false} />
-      <div>
+      <div className="page-container">
+        <Sidebar currentPath={0} />
         <form className="registration">
           <label>
             Enter your Club Name: <br />

--- a/frontend/src/components/ClubRegistration/Sidebar.tsx
+++ b/frontend/src/components/ClubRegistration/Sidebar.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const sidebarItems = ['Profile', 'Recruitment Banner', 'Description', 'Events'];
+const sidebarPaths = ['profile', 'recruitment', 'description', 'events'];
+
+// Required props
+interface RequiredProps {
+  currentPath: number;
+}
+
+// Optional props
+interface OptionalProps {}
+
+// Combine required and optional props to build the full prop interface
+interface Props extends RequiredProps, OptionalProps {}
+
+// Use the optional prop interface to define the default props
+const defaultProps: OptionalProps = {};
+
+const Sidebar = (props: Props) => {
+  const importedNavTo = useNavigate();
+  const navigateTo = (path: string) => {
+    importedNavTo('/register/' + path);
+  };
+
+  return (
+    <div className="sidebar">
+      {sidebarPaths.map((path, index) => {
+        return (
+          <button
+            className={
+              index === props.currentPath
+                ? 'sidebar-item-highlighted'
+                : 'sidebar-item'
+            }
+            onClick={() => navigateTo(path)}
+          >
+            {sidebarItems[index]}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+Sidebar.defaultProps = defaultProps;
+
+export { sidebarPaths, sidebarItems };
+export default Sidebar;

--- a/frontend/src/components/NavBar/NavBar.css
+++ b/frontend/src/components/NavBar/NavBar.css
@@ -61,6 +61,7 @@
 .logo {
   position: fl;
   margin-left: 4.5rem;
+  margin-top: 1.563rem;
 }
 
 .profileButton {

--- a/frontend/src/components/NavBar/NavBar.tsx
+++ b/frontend/src/components/NavBar/NavBar.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { logo } from '../../icons/navbar';
-import Handle from '../../assets/handle.svg';
-import Ellipse from '../../assets/ellipse.svg';
 import './NavBar.css';
 import ProfileButton from './ProfileButton/ProfileButton';
 

--- a/frontend/src/components/NavBar/ProfileButton/ProfileButton.css
+++ b/frontend/src/components/NavBar/ProfileButton/ProfileButton.css
@@ -103,7 +103,7 @@
 }
 
 .collapseArrow {
-  transform: translateX(-10px);
+  transform: translateX(-20px);
 }
 
 .expandArrow {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request is the first step towards implementing a functional sidebar.

From the ClubRegistration page, clicking on Sidebar items now routes you to one of four Routes and four corresponding pages: ClubProfile, ClubRecruitment, ClubDescription, and ClubEvents.

### Test Plan <!-- Required -->

Not much, as it's front-end only.

### Notes <!-- Optional -->

NOTES!

- From the Figma designs, I was unsure whether the ClubRegistration page should be one of the four sidebar options by default. For now, I have it as a separate "default" page. However, this can be changed pretty easily - just let me know.
- I designed the Sidebar.tsx component to be included on the left of any page navigable to and from the sidebar. It takes a prop that indicates which path/page it's currently on. This is perhaps not the most elegant solution possible, but it's hard to handle React Routing more dynamically than this. I'm welcome to restructuring suggestions, however.
- For ease of use, I've setup the Sidebar component to export the const sidebarItems (the human-readable names to be rendered, in-order) and the const sidebarPaths (the React Router routes for each page, in-order).

