### PR TITLE
Dlw266/better register sidebar

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,12 @@
 .App {
   text-align: center;
-  padding: 0% 2%;
+  padding: 0 0;
+  margin: 0 0;
+}
+
+body {
+  padding: 0 0;
+  margin: 0 0;
 }
 
 .App-logo {

--- a/frontend/src/components/ClubRegistration/ClubRegistration.css
+++ b/frontend/src/components/ClubRegistration/ClubRegistration.css
@@ -4,3 +4,7 @@
   flex-direction: column;
   gap: 1em;
 }
+
+.displayed-page {
+  padding-left: 3em;
+}

--- a/frontend/src/components/ClubRegistration/ClubRegistration.tsx
+++ b/frontend/src/components/ClubRegistration/ClubRegistration.tsx
@@ -2,8 +2,12 @@ import React, { useState } from 'react';
 import './ClubRegistration.css';
 import Dropdown from './Dropdown/Dropdown';
 import NavBar from '../../components/NavBar/NavBar';
+import Sidebar, { sidebarItems } from './Sidebar/Sidebar';
 
 const ClubRegistration = () => {
+  // Control the sidebar value to indicate which page we're on (indexed 0-3 in reference to sidebarItems)
+  const [currentDisplay, setCurrentDisplay] = useState<number>(0);
+
   // Controlled values for all the form elements
   const [name, setName] = useState('');
   const [category, setCategory] = useState('');
@@ -21,74 +25,92 @@ const ClubRegistration = () => {
     //NOT IMPLEMENTED: SUBMIT DATA STORED IN REACT HOOKS TO BACKEND
   }
 
+  function changeDisplayedPage(newIndex: number) {
+    setCurrentDisplay(newIndex);
+  }
+
+  const pages = [];
+
+  // 0: Profile (default registration page)
+  pages.push(
+    <form className="registration">
+      <label>
+        Enter your Club Name: <br />
+        <input
+          name="clubName"
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </label>
+
+      <Dropdown callback={setCategory} />
+
+      <label>
+        Enter your Email: <br />
+        <input
+          name="clubEmail"
+          type="text"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+      </label>
+
+      <label>
+        Enter a Description of your Club: <br />
+        <textarea
+          name="clubDescr"
+          value={descr}
+          onChange={(event) => setDescr(event.target.value)}
+        />
+      </label>
+
+      <label>
+        Enter a link to your Club Website: <br />
+        <input
+          name="clubURL"
+          type="text"
+          value={URL}
+          onChange={(event) => setURL(event.target.value)}
+        />
+      </label>
+
+      <label>
+        Enter the Opening Date: <br />
+        <input
+          name="clubOpenDate"
+          type="date"
+          value={openDate}
+          onChange={(event) => setOpenDate(event.target.value)}
+        />
+      </label>
+
+      <label>
+        Enter the Closing Date: <br />
+        <input
+          name="clubCloseDate"
+          type="date"
+          value={closeDate}
+          onChange={(event) => setCloseDate(event.target.value)}
+        />
+      </label>
+
+      <button onClick={(e) => handleSubmit(e)}>Submit</button>
+    </form>
+  );
+  // 1: Recruitment page
+  pages.push(<h1>Club Recruitment Page</h1>);
+  // 2: Description page
+  pages.push(<h1>Club Description Page</h1>);
+  // 3: Club Events page
+  pages.push(<h1>Club Events Page</h1>);
+
   return (
     <>
       <NavBar hasSearch={false} />
-      <div>
-        <form className="registration">
-          <label>
-            Enter your Club Name: <br />
-            <input
-              name="clubName"
-              type="text"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-            />
-          </label>
-
-          <Dropdown callback={setCategory} />
-
-          <label>
-            Enter your Email: <br />
-            <input
-              name="clubEmail"
-              type="text"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-            />
-          </label>
-
-          <label>
-            Enter a Description of your Club: <br />
-            <textarea
-              name="clubDescr"
-              value={descr}
-              onChange={(event) => setDescr(event.target.value)}
-            />
-          </label>
-
-          <label>
-            Enter a link to your Club Website: <br />
-            <input
-              name="clubURL"
-              type="text"
-              value={URL}
-              onChange={(event) => setURL(event.target.value)}
-            />
-          </label>
-
-          <label>
-            Enter the Opening Date: <br />
-            <input
-              name="clubOpenDate"
-              type="date"
-              value={openDate}
-              onChange={(event) => setOpenDate(event.target.value)}
-            />
-          </label>
-
-          <label>
-            Enter the Closing Date: <br />
-            <input
-              name="clubCloseDate"
-              type="date"
-              value={closeDate}
-              onChange={(event) => setCloseDate(event.target.value)}
-            />
-          </label>
-
-          <button onClick={(e) => handleSubmit(e)}>Submit</button>
-        </form>
+      <div className="page-container">
+        <Sidebar currentItem={currentDisplay} callback={changeDisplayedPage} />
+        <div className="displayed-page">{pages[currentDisplay]}</div>
       </div>
     </>
   );

--- a/frontend/src/components/ClubRegistration/Sidebar/Sidebar.css
+++ b/frontend/src/components/ClubRegistration/Sidebar/Sidebar.css
@@ -1,0 +1,62 @@
+.page-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+}
+
+.sidebar {
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  align-self: flex-start;
+}
+
+.sidebar-item {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+
+  height: 50px;
+
+  font-family: 'Nunito';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 27px;
+
+  color: #35c1fd;
+
+  text-align: left;
+  padding-left: 75px;
+}
+
+.sidebar-item-highlighted {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+
+  font-family: 'Nunito';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 27px;
+
+  height: 50px;
+
+  color: #35c1fd;
+  border-radius: 0 20px 20px 0;
+  background: #35c1fd1a;
+
+  text-align: left;
+  padding-left: 75px;
+}

--- a/frontend/src/components/ClubRegistration/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/ClubRegistration/Sidebar/Sidebar.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import './Sidebar.css';
+
+const sidebarItems = ['Profile', 'Recruitment Banner', 'Description', 'Events'];
+
+// Required props
+interface RequiredProps {
+  currentItem: any;
+  callback: (clickedItem: number) => void;
+}
+
+// Optional props
+interface OptionalProps {}
+
+// Combine required and optional props to build the full prop interface
+interface Props extends RequiredProps, OptionalProps {}
+
+// Use the optional prop interface to define the default props
+const defaultProps: OptionalProps = {};
+
+const Sidebar: React.FC<Props> = (props: Props) => {
+  return (
+    <div className="sidebar">
+      {sidebarItems.map((name, index) => {
+        return (
+          <button
+            className={
+              index === props.currentItem
+                ? 'sidebar-item-highlighted'
+                : 'sidebar-item'
+            }
+            onClick={() => props.callback(index)}
+          >
+            {sidebarItems[index]}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+Sidebar.defaultProps = defaultProps;
+
+export { sidebarItems };
+export default Sidebar;

--- a/frontend/src/components/NavBar/NavBar.css
+++ b/frontend/src/components/NavBar/NavBar.css
@@ -61,6 +61,7 @@
 .logo {
   position: fl;
   margin-left: 4.5rem;
+  margin-top: 1.563rem;
 }
 
 .profileButton {

--- a/frontend/src/components/NavBar/ProfileButton/ProfileButton.css
+++ b/frontend/src/components/NavBar/ProfileButton/ProfileButton.css
@@ -103,7 +103,7 @@
 }
 
 .collapseArrow {
-  transform: translateX(-10px);
+  transform: translateX(-20px);
 }
 
 .expandArrow {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request is the first step towards implementing a functional sidebar.

From the ClubRegistration page, clicking on Sidebar items now displays one of four corresponding sub-pages: ClubProfile, ClubRecruitment, ClubDescription, and ClubEvents. It does this without changing routes, as discussed with Aaron. Instead, state is preserved across all four tabs. The Sidebar component's state is managed by the parent component page, including a callback that indicates when the user has clicked on one of the options.

### Test Plan <!-- Required -->

Not much, as it's front-end only.

### Notes <!-- Optional -->

- My main concern with this implementation (as opposed to the the one in PR 55: https://github.com/cornell-dti/club-view/pull/55) is that the page will become really large (as discussed with Aaron).

